### PR TITLE
fix: Load settings when plugin initially loads

### DIFF
--- a/RomeFormatter.py
+++ b/RomeFormatter.py
@@ -25,7 +25,14 @@ from os import path
 from sublime import Region, load_settings, expand_variables
 
 WINDOWS = platform.system() == 'Windows'
-settings = load_settings('RomeFormatter.sublime-settings')
+SETTINGS_FILE = 'RomeFormatter.sublime-settings'
+settings = {}
+
+
+def plugin_loaded():
+	global settings
+	settings = load_settings(SETTINGS_FILE)
+
 
 supported_scopes = (
 	("source.js", ".js"),


### PR DESCRIPTION
It seems that the settings are currently not loading when Sublime Text starts, and so the feature to auto-format file upon save is not working (on MacOS at least).

This change loads the package's settings at the appropriate time, under the 'plugin_loaded' function.